### PR TITLE
Update all occurrences of r888888888 to danbooru

### DIFF
--- a/ext/dtext/dtext.c
+++ b/ext/dtext/dtext.c
@@ -17579,7 +17579,7 @@ gboolean parse_helper(StateMachine* sm) {
 #line 219 "ext/dtext/dtext.rl"
 			{( sm->te) = ( sm->p);( sm->p) = ( sm->p) - 1;{
 #line 219 "ext/dtext/dtext.rl"
-					append_id_link(sm, "issue", "github", "https://github.com/r888888888/danbooru/issues/"); }
+					append_id_link(sm, "issue", "github", "https://github.com/danbooru/danbooru/issues/"); }
 			}}
 		
 #line 17586 "ext/dtext/dtext.c"

--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -216,7 +216,7 @@ inline := |*
   'feedback #'i id    => { append_id_link(sm, "feedback", "user-feedback", "/user_feedbacks/"); };
   'wiki #'i id        => { append_id_link(sm, "wiki", "wiki-page", "/wiki_pages/"); };
 
-  'issue #'i id            => { append_id_link(sm, "issue", "github", "https://github.com/r888888888/danbooru/issues/"); };
+  'issue #'i id            => { append_id_link(sm, "issue", "github", "https://github.com/danbooru/danbooru/issues/"); };
   'artstation #'i alnum_id => { append_id_link(sm, "artstation", "artstation", "https://www.artstation.com/artwork/"); };
   'deviantart #'i id       => { append_id_link(sm, "deviantart", "deviantart", "https://www.deviantart.com/deviation/"); };
   'nijie #'i id            => { append_id_link(sm, "nijie", "nijie", "https://nijie.info/view.php?id="); };

--- a/lib/dtext_ruby.rb
+++ b/lib/dtext_ruby.rb
@@ -133,7 +133,7 @@ class DTextRuby
     str = str.gsub(/\bpool #(\d+)/i, %{<a href="/pools/\\1">pool #\\1</a>})
     str = str.gsub(/\buser #(\d+)/i, %{<a href="/users/\\1">user #\\1</a>})
     str = str.gsub(/\bartist #(\d+)/i, %{<a href="/artists/\\1">artist #\\1</a>})
-    str = str.gsub(/\bissue #(\d+)/i, %{<a href="https://github.com/r888888888/danbooru/issues/\\1">issue #\\1</a>})
+    str = str.gsub(/\bissue #(\d+)/i, %{<a href="https://github.com/danbooru/danbooru/issues/\\1">issue #\\1</a>})
     str = str.gsub(/\bpixiv #(\d+)(?!\/p\d|\d)/i, %{<a href="http://www.pixiv.net/member_illust.php?mode=medium&illust_id=\\1">pixiv #\\1</a>})
     str = str.gsub(/\bpixiv #(\d+)\/p(\d+)/i, %{<a href="http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=\\1&page=\\2">pixiv #\\1/p\\2</a>})
   end

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -409,7 +409,7 @@ class DTextTest < Minitest::Test
     assert_parse_id_link("dtext-moderation-report-id-link", "/moderation_reports/1234", "modreport #1234")
     assert_parse_id_link("dtext-dmail-id-link", "/dmails/1234", "dmail #1234")
 
-    assert_parse_id_link("dtext-github-id-link", "https://github.com/r888888888/danbooru/issues/1234", "issue #1234")
+    assert_parse_id_link("dtext-github-id-link", "https://github.com/danbooru/danbooru/issues/1234", "issue #1234")
     assert_parse_id_link("dtext-artstation-id-link", "https://www.artstation.com/artwork/A1", "artstation #A1")
     assert_parse_id_link("dtext-deviantart-id-link", "https://www.deviantart.com/deviation/1234", "deviantart #1234")
     assert_parse_id_link("dtext-nijie-id-link", "https://nijie.info/view.php?id=1234", "nijie #1234")


### PR DESCRIPTION
I'm not really sure if I did it correct, but this should close https://github.com/danbooru/danbooru/issues/4847, so using `issue` on danbooru will link to correct namespace.